### PR TITLE
Use Scripting.Dictionary to support Word

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ For an advanced example of what is possible with vba-test, check out the [tests 
 
 1. Download the [latest release (v2.0.0-beta.3)](https://github.com/vba-tools/vba-test/releases)
 2. Add `src/TestSuite.cls`, `src/TestCase.cls`, add `src/ImmediateReporter.cls` to your project
-3. If you're starting from scratch with Excel, you can use `vba-test-blank.xlsm`
+3. In the VBA Editor, select Tools | References and make sure `Microsoft Scripting Runtime` is checked
+
+If you're starting from scratch with Excel, you can use `vba-test-blank.xlsm`
 
 If you're updating from Excel-TDD v1, follow these [upgrade details](https://github.com/VBA-tools/vba-test/pull/23#issuecomment-416606307).
 

--- a/src/TestCase.cls
+++ b/src/TestCase.cls
@@ -26,7 +26,7 @@ Private pFailures As VBA.Collection
 ' --------------------------------------------- '
 
 Public Name As String
-Public Context As Dictionary
+Public Context As Scripting.Dictionary
 
 Public Planned As Long
 Public Successes As Long
@@ -575,7 +575,7 @@ Private Function Indent(Optional Indentation As Long)
 End Function
 
 Private Sub Class_Initialize()
-    Set Me.Context = New Dictionary
+    Set Me.Context = New Scripting.Dictionary
     Set pFailures = New VBA.Collection
 End Sub
 

--- a/tests/Tests_TestCase.bas
+++ b/tests/Tests_TestCase.bas
@@ -109,11 +109,11 @@ Sub PassingAssertions(Suite As TestSuite)
         
         .IsEqual A, B
         
-        Set A = New Dictionary
+        Set A = New Scripting.Dictionary
         A("a") = 1
         A("b") = 2
         
-        Set B = New Dictionary
+        Set B = New Scripting.Dictionary
         B("a") = 1
         B("b") = 2
         
@@ -136,11 +136,11 @@ Sub PassingAssertions(Suite As TestSuite)
         
         .NotEqual A, B
         
-        Set A = New Dictionary
+        Set A = New Scripting.Dictionary
         A("a") = 1
         A("b") = 2
         
-        Set B = New Dictionary
+        Set B = New Scripting.Dictionary
         B("a") = 2
         B("b") = 1
         


### PR DESCRIPTION
Thanks for creating this project!  I am using it on Word VBA.  However, on Word, `Dictionary` is ambiguous, since it could be `Word.Dictionary` or `Scripting.Dictionary`.  This PR specifies `Scripting` to avoid compilation failures.

All tests pass on both Excel 2013 and Word 2013.

Thanks for considering this PR!