### PR TITLE
Add FileReporter

### DIFF
--- a/src/FileReporter.cls
+++ b/src/FileReporter.cls
@@ -2,30 +2,31 @@ VERSION 1.0 CLASS
 BEGIN
   MultiUse = -1  'True
 END
-Attribute VB_Name = "ImmediateReporter"
+Attribute VB_Name = "FileReporter"
 Attribute VB_GlobalNameSpace = False
 Attribute VB_Creatable = False
 Attribute VB_PredeclaredId = False
 Attribute VB_Exposed = True
 ''
-' ImmediateReporter v2.0.0-beta.3
+' FileReporter v2.0.0-beta.3
 ' (c) Tim Hall - https://github.com/vba-tools/vba-test
 '
-' Report results to Immediate Window
+' Report results to file
 '
-' @class ImmediateReporter
+' @class FileReporter
 ' @author tim.hall.engr@gmail.com
 ' @license MIT (https://opensource.org/licenses/MIT)
 ' ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ '
 Option Explicit
 
 Private WithEvents pSuite As TestSuite
-Attribute pSuite.VB_VarHelpID = -1
+Private FilePath As String
 Private Finished As Boolean
 
-''
-' Listen to given TestSuite
-''
+Public Sub WriteTo(Path As Variant)
+    FilePath = Path
+End Sub
+
 Public Sub ListenTo(Suite As TestSuite)
     If Not pSuite Is Nothing Then
         PrintSummary
@@ -37,11 +38,7 @@ Public Sub ListenTo(Suite As TestSuite)
 End Sub
 
 Private Sub PrintHeader(Suite As TestSuite)
-    Debug.Print "===" & IIf(Suite.Description <> "", " " & Suite.Description & " ===", "")
-End Sub
-
-Private Sub PrintGroup(Suite As TestSuite)
-    Debug.Print "===" & IIf(Suite.Description <> "", " " & Suite.Description & " ===", "")
+    AppendToFile "===" & VBA.IIf(Suite.Description <> "", " " & Suite.Description & " ===", "")
 End Sub
 
 Private Sub PrintResult(Test As TestCase)
@@ -49,12 +46,12 @@ Private Sub PrintResult(Test As TestCase)
         Exit Sub
     End If
 
-    Debug.Print ResultTypeToString(Test.Result) & " " & Test.Description
+    AppendToFile ResultTypeToString(Test.Result) & " " & Test.Description
     
     If Test.Result = TestResultType.Fail Then
         Dim Failure As Variant
         For Each Failure In Test.Failures
-            Debug.Print "  " & Failure
+            AppendToFile "  " & Failure
         Next Failure
     End If
 End Sub
@@ -87,7 +84,7 @@ Private Sub PrintSummary()
         Summary = Summary & ")"
     End If
 
-    Debug.Print "= " & Summary & " = " & Now & " =" & vbNewLine
+    AppendToFile "= " & Summary & " = " & Now & " =" & vbNewLine
 End Sub
 
 Private Function ResultTypeToString(ResultType As TestResultType) As String
@@ -101,12 +98,27 @@ Private Function ResultTypeToString(ResultType As TestResultType) As String
     End Select
 End Function
 
-Private Sub pSuite_Group(Suite As TestSuite)
-    PrintGroup Suite
+Private Sub AppendToFile(Message As String)
+    If FilePath = "" Then Exit Sub
+    
+    Dim File As Integer
+    File = FreeFile
+    
+    On Error GoTo Cleanup
+    
+    Open FilePath For Append As #File
+    Print #File, Message
+    
+Cleanup:
+    Close #File
 End Sub
 
 Private Sub pSuite_Result(Test As TestCase)
     PrintResult Test
+End Sub
+
+Private Sub pSuite_Group(Suite As TestSuite)
+    PrintHeader Suite
 End Sub
 
 Private Sub Class_Terminate()
@@ -114,3 +126,4 @@ Private Sub Class_Terminate()
         PrintSummary
     End If
 End Sub
+

--- a/src/TestSuite.cls
+++ b/src/TestSuite.cls
@@ -147,8 +147,6 @@ End Function
 ' @internal
 ''
 Public Sub TestComplete(Test As TestCase)
-    Tests.Add Test
-
     OnTestResult Test
     OnTestAfter Test
 End Sub
@@ -168,6 +166,7 @@ End Sub
 ' @internal
 ''
 Public Sub OnTestResult(Test As TestCase)
+    Tests.Add Test
     RaiseEvent Result(Test)
     
     If Not Me.Parent Is Nothing Then

--- a/tests/Tests.bas
+++ b/tests/Tests.bas
@@ -1,5 +1,17 @@
 Attribute VB_Name = "Tests"
-Public Sub RunTests()
-    Tests_TestSuite.Tests
-    Tests_TestCase.Tests
+Public Sub Run(Optional Output As Variant)
+    Dim Suite As New TestSuite
+    Suite.Description = "vba-test"
+
+    Dim Immediate As New ImmediateReporter
+    Immediate.ListenTo Suite
+
+    If Not IsMissing(Output) And CStr(Output) <> "" Then
+        Dim Reporter As New FileReporter
+        Reporter.WriteTo Output
+        Reporter.ListenTo Suite
+    End If
+
+    Tests_TestSuite.RunTests Suite.Group("TestSuite")
+    Tests_TestCase.RunTests Suite.Group("TestCase")
 End Sub

--- a/tests/Tests_TestCase.bas
+++ b/tests/Tests_TestCase.bas
@@ -1,18 +1,12 @@
 Attribute VB_Name = "Tests_TestCase"
-Public Function Tests() As TestSuite
-    Set Tests = New TestSuite
-    Tests.Description = "TestCase"
-    
-    Dim Reporter As New ImmediateReporter
-    Reporter.ListenTo Tests
-    
-    Dim Suite As New TestSuite
+Public Sub RunTests(Suite As TestSuite)
+    Dim Tests As New TestSuite
     Dim Test As TestCase
     Dim A As Variant
     Dim B As Variant
     
-    With Tests.Test("should pass if all assertions pass")
-        Set Test = Suite.Test("should pass")
+    With Suite.Test("should pass if all assertions pass")
+        Set Test = Tests.Test("should pass")
         With Test
             .IsEqual "A", "A"
             .IsEqual 2, 2
@@ -21,8 +15,8 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Result, TestResultType.Pass
     End With
     
-    With Tests.Test("should fail if any assertion fails")
-        Set Test = Suite.Test("should fail")
+    With Suite.Test("should fail if any assertion fails")
+        Set Test = Tests.Test("should fail")
         With Test
             .IsEqual "A", "A"
             .IsEqual 2, 1
@@ -31,8 +25,8 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Result, TestResultType.Fail
     End With
     
-    With Tests.Test("should contain collection of failures")
-        Set Test = Suite.Test("should have failures")
+    With Suite.Test("should contain collection of failures")
+        Set Test = Tests.Test("should have failures")
         With Test
             .IsEqual "A", "A"
             .IsEqual 2, 1
@@ -43,13 +37,13 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Failures(2), "Expected True to equal False"
     End With
     
-    With Tests.Test("should be pending if there are no assertions")
-        Set Test = Suite.Test("pending")
+    With Suite.Test("should be pending if there are no assertions")
+        Set Test = Tests.Test("pending")
         .IsEqual Test.Result, TestResultType.Pending
     End With
     
-    With Tests.Test("should skip even with failed assertions")
-        Set Test = Suite.Test("skipped")
+    With Suite.Test("should skip even with failed assertions")
+        Set Test = Tests.Test("skipped")
         With Test
             .IsEqual 2, 1
             .Skip
@@ -58,8 +52,8 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Result, TestResultType.Skipped
     End With
     
-    With Tests.Test("should explicitly pass test")
-        Set Test = Suite.Test("pass")
+    With Suite.Test("should explicitly pass test")
+        Set Test = Tests.Test("pass")
         With Test
             .IsEqual 2, 1
             .Pass
@@ -68,8 +62,8 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Result, TestResultType.Pass
     End With
     
-    With Tests.Test("should explicitly fail test")
-        Set Test = Suite.Test("fail")
+    With Suite.Test("should explicitly fail test")
+        Set Test = Tests.Test("fail")
         With Test
             .IsEqual 2, 2
             .Fail
@@ -78,8 +72,8 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Result, TestResultType.Fail
     End With
     
-    With Tests.Test("should fail if plan doesn't match")
-        Set Test = Suite.Test("plan")
+    With Suite.Test("should fail if plan doesn't match")
+        Set Test = Tests.Test("plan")
         With Test
             .Plan 2
             .IsEqual 2, 2
@@ -88,9 +82,9 @@ Public Function Tests() As TestSuite
         .IsEqual Test.Result, TestResultType.Fail
     End With
     
-    PassingAssertions Tests
-    FailingAssertions Tests
-End Function
+    PassingAssertions Suite
+    FailingAssertions Suite
+End Sub
 
 Sub PassingAssertions(Suite As TestSuite)
     With Suite.Test("IsEqual")

--- a/tests/Tests_TestSuite.bas
+++ b/tests/Tests_TestSuite.bas
@@ -1,82 +1,75 @@
 Attribute VB_Name = "Tests_TestSuite"
-Public Function Tests() As TestSuite
-    Dim Suite As New TestSuite
-    
-    Set Tests = New TestSuite
-    Tests.Description = "TestSuite"
-    
-    Dim Reporter As New ImmediateReporter
-    Reporter.ListenTo Tests
-    
+Public Sub RunTests(Suite As TestSuite)
+    Dim Tests As TestSuite
     Dim Fixture As New Test_Fixture
-    Fixture.ListenTo Tests
+    Fixture.ListenTo Suite
     
-    With Tests.Test("should fire BeforeEach event")
+    With Suite.Test("should fire BeforeEach event")
         .IsEqual Fixture.BeforeEachCallCount, 1
     End With
     
-    With Tests.Test("should fire Result event")
+    With Suite.Test("should fire Result event")
         .IsEqual Fixture.ResultCalls(1).Description, "should fire BeforeEach event"
         .IsEqual Fixture.ResultCalls(1).Result, TestResultType.Pass
     End With
     
-    With Tests.Test("should fire AfterEach event")
+    With Suite.Test("should fire AfterEach event")
         .IsEqual Fixture.AfterEachCallCount, 2
     End With
     
-    With Tests.Test("should store specs")
-        Set Suite = New TestSuite
-        With Suite.Test("(pass)")
+    With Suite.Test("should store specs")
+        Set Tests = New TestSuite
+        With Tests.Test("(pass)")
             .IsEqual 4, 4
         End With
-        With Suite.Test("(fail)")
+        With Tests.Test("(fail)")
             .IsEqual 4, 3
         End With
-        With Suite.Test("(pending)")
+        With Tests.Test("(pending)")
         End With
-        With Suite.Test("(skipped)")
+        With Tests.Test("(skipped)")
             .Skip
         End With
 
-        .IsEqual Suite.Tests.Count, 4
-        .IsEqual Suite.PassedTests.Count, 1
-        .IsEqual Suite.FailedTests.Count, 1
-        .IsEqual Suite.PendingTests.Count, 1
-        .IsEqual Suite.SkippedTests.Count, 1
+        .IsEqual Tests.Tests.Count, 4
+        .IsEqual Tests.PassedTests.Count, 1
+        .IsEqual Tests.FailedTests.Count, 1
+        .IsEqual Tests.PendingTests.Count, 1
+        .IsEqual Tests.SkippedTests.Count, 1
         
-        .IsEqual Suite.PassedTests(1).Description, "(pass)"
-        .IsEqual Suite.FailedTests(1).Description, "(fail)"
-        .IsEqual Suite.PendingTests(1).Description, "(pending)"
-        .IsEqual Suite.SkippedTests(1).Description, "(skipped)"
+        .IsEqual Tests.PassedTests(1).Description, "(pass)"
+        .IsEqual Tests.FailedTests(1).Description, "(fail)"
+        .IsEqual Tests.PendingTests(1).Description, "(pending)"
+        .IsEqual Tests.SkippedTests(1).Description, "(skipped)"
     End With
 
-    With Tests.Test("should have overall result")
-        Set Suite = New TestSuite
+    With Suite.Test("should have overall result")
+        Set Tests = New TestSuite
 
-        .IsEqual Suite.Result, TestResultType.Pending
+        .IsEqual Tests.Result, TestResultType.Pending
 
-        With Suite.Test("(pending)")
+        With Tests.Test("(pending)")
         End With
 
-        .IsEqual Suite.Result, TestResultType.Pending
+        .IsEqual Tests.Result, TestResultType.Pending
 
-        With Suite.Test("(pass)")
+        With Tests.Test("(pass)")
             .IsEqual 4, 4
         End With
 
-        .IsEqual Suite.Result, TestResultType.Pass
+        .IsEqual Tests.Result, TestResultType.Pass
 
-        With Suite.Test("(fail)")
+        With Tests.Test("(fail)")
             .IsEqual 4, 3
         End With
 
-        .IsEqual Suite.Result, TestResultType.Fail
+        .IsEqual Tests.Result, TestResultType.Fail
 
-        With Suite.Test("(pass)")
+        With Tests.Test("(pass)")
             .IsEqual 2, 2
         End With
 
-        .IsEqual Suite.Result, TestResultType.Fail
+        .IsEqual Tests.Result, TestResultType.Fail
     End With
 
-End Function
+End Sub

--- a/vba-block.toml
+++ b/vba-block.toml
@@ -7,6 +7,7 @@ authors = ["Tim Hall <tim.hall.engr@gmail.com> (https://github.com/timhall)"]
 TestSuite = "src/TestSuite.cls"
 TestCase = "src/TestCase.cls"
 ImmediateReporter = "src/ImmediateReporter.cls"
+FileReporter = "src/FileReporter.cls"
 
 [dependencies]
 dictionary = "^1"


### PR DESCRIPTION
Testing can now be done from the command line with `vba run --target xlsm Tests.Run CON` (Windows) or `vba run --target xlsm Tests.Run /dev/stdout` (Mac)