### PR TITLE
Set source file language to VBA in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,7 @@
 *.PDF  diff=astextplain
 *.rtf  diff=astextplain
 *.RTF  diff=astextplain
+
+# Clarify that the source language is VBA (Auto-detection not always accurate)
+*.bas linguist-language=VBA
+*.cls linguist-language=VBA


### PR DESCRIPTION
GitHub's language auto-detection usually assumes that `.bas` and `.cls` files are VB.NET. This change clarifies that these file extensions represent VBA files in this repository.

![image](https://user-images.githubusercontent.com/7254992/145095582-35252900-9ee0-4cd7-abf8-493298cda560.png)
This change helps new users recognize at a glance that this is a VBA project, not a .NET project, and can improve discoverability when people are searching for VBA source files related to automated testing.